### PR TITLE
Fix: Remove deprecated component setup function calls

### DIFF
--- a/custom_components/rheem_eziset/__init__.py
+++ b/custom_components/rheem_eziset/__init__.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(hass.config_entries.async_forward_entry_setup(entry, platform))
+            hass.async_add_job(hass.config_entries.async_forward_entry_setups(entry, [platform]))
 
     entry.add_update_listener(async_reload_entry)  # Reload the entry on configuration changes.
 

--- a/custom_components/rheem_eziset/manifest.json
+++ b/custom_components/rheem_eziset/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/illuzn/rheem-eziset/issues",
-  "version": "2023.12.0"
+  "version": "2025.8.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Rheem EziSET",
-  "homeassistant": "2023.8.0",
+  "homeassistant": "2025.8.2",
   "render_readme": true
 }


### PR DESCRIPTION
Minor fixes to get this integration working again and remove deprecated component setup function calls that were retired in Home Assistant release 2025.6.0 (PR: https://github.com/home-assistant/core/pull/144560).

Cheers.